### PR TITLE
Move clap to subcommands

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Output extensions
+    #[arg(short, long)]
+    pub format: Option<String>,
+
+    #[clap(subcommand)]
+    pub cmd: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Subcommand to compile
+    #[clap(alias = "build")]
+    Compile {
+        /// Input files to compile
+        #[arg(value_name = "FILE PATH", index = 1)]
+        files: Vec<PathBuf>,
+    },
+    /// Subcommand to decompile
+    #[clap(alias = "decomp")]
+    Decompile {
+        /// Input files to decompile
+        #[arg(value_name = "FILE PATH", index = 1)]
+        files: Vec<PathBuf>,
+    },
+}

--- a/src/bandb/byte.rs
+++ b/src/bandb/byte.rs
@@ -13,7 +13,14 @@ impl Byte {
     pub fn from_str(str: &str) -> Self {
         let mut vec: Vec<u8> = vec![];
         for b in str.bytes() {
-            vec.push(u8::try_from((b as char).to_digit(10).expect("Cannot convert vec to digit")).expect("Cannot cast u32 to u8"));
+            vec.push(
+                u8::try_from(
+                    (b as char)
+                        .to_digit(10)
+                        .expect("Cannot convert vec to digit"),
+                )
+                .expect("Cannot cast u32 to u8"),
+            );
         }
         let byte = convert_vec_to_u8(&vec);
         Byte { value: byte }

--- a/src/bandb/mod.rs
+++ b/src/bandb/mod.rs
@@ -1,2 +1,2 @@
-pub mod byte;
 pub mod bits;
+pub mod byte;


### PR DESCRIPTION
This proposal comes with the intention of making the arguments of the cli more robust (and rust like)

Move commands from:

```
noc -fjpg cat.nc
noc --decomp -fnc cat.jpg
```

to:

```
noc -fjpg compile cat.nc
noc -fnc decompile cat.jpg
```

And have aliases, like:

```
noc -fjpg build cat.nc
noc -fnc decomp cat.jpg
```

Some improvements not related with changes:
- Format Code

> [!NOTE]
> I remove the `--output` argument because when receiving multiple inputs to compile/decompile it does not make sense to have a custom output unless a link operation is performed like ld/mold/gold/rustld does.
>
> Although we could make the output actually be the folder where the generated files would be stored.